### PR TITLE
fix: Remove wrong datatypes and associations in Courses and ReadingMa…

### DIFF
--- a/src/models/course/Course.ts
+++ b/src/models/course/Course.ts
@@ -5,7 +5,6 @@ import {
   DataType,
   PrimaryKey,
   ForeignKey,
-  BelongsTo,
 } from "sequelize-typescript";
 
 import Instructor from "../user/Instructor";
@@ -27,8 +26,6 @@ class Course extends Model {
     allowNull: false,
   })
   instructorId!: string;
-
-  @BelongsTo(() => Instructor)
 
   @Column({
     type: DataType.STRING,
@@ -67,7 +64,7 @@ class Course extends Model {
   price!: number;
 
   @Column({
-    type: DataType.NUMBER,
+    type: DataType.FLOAT,
     allowNull: false,
   })
   rating!: number;

--- a/src/models/course/ReadingMaterial.ts
+++ b/src/models/course/ReadingMaterial.ts
@@ -28,6 +28,8 @@ class ReadingMaterial extends Model {
   moduleId!: string;
 
   @BelongsTo(() => Module)
+  module!: Module;
+  
   @Column({
     type: DataType.STRING,
     allowNull: false,


### PR DESCRIPTION
This pull request includes changes to the `Course` and `ReadingMaterial` models to improve their structure and data types. The most important changes include removing the `BelongsTo` decorator for the `Instructor` association, changing the data type of the `rating` column, and adding a new property to the `ReadingMaterial` model.

Changes to `Course` model:

* Removed the `BelongsTo` decorator for the `Instructor` association in the `Course` model.
* Changed the data type of the `rating` column from `DataType.NUMBER` to `DataType.FLOAT`.

Changes to `ReadingMaterial` model:

* Added a new property `module` to the `ReadingMaterial` model to establish the association with the `Module` model.

Other changes:

* Removed the `BelongsTo` import from `sequelize-typescript` in the `Course` model file.…terial models